### PR TITLE
Negative number in Census Dialog + Hide VP during game

### DIFF
--- a/src/net/bubbaland/megaciv/client/gui/AstTablePanel.java
+++ b/src/net/bubbaland/megaciv/client/gui/AstTablePanel.java
@@ -681,8 +681,10 @@ public class AstTablePanel extends BubbaPanel {
 						component.setToolTipText(civ.getTechBreakdownString());
 						break;
 					case VP:
-						text = String.format("%1$3d", civ.getVP());
-						component.setToolTipText(civ.getVpBreakdownString());
+						if(AstTablePanel.this.client.getGame().isGameOver() || AstTablePanel.this.client.getGame().showVP()) {
+							text = String.format("%1$3d", civ.getVP());
+							component.setToolTipText(civ.getVpBreakdownString());
+						}
 						break;
 					case BUY:
 						this.buyButton

--- a/src/net/bubbaland/megaciv/client/gui/CensusDialog.java
+++ b/src/net/bubbaland/megaciv/client/gui/CensusDialog.java
@@ -10,6 +10,8 @@ import java.util.Properties;
 import javax.swing.JOptionPane;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingConstants;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
 
 import org.apache.commons.lang3.text.WordUtils;
 
@@ -115,10 +117,29 @@ public class CensusDialog extends BubbaDialogPanel {
 
 			constraints.gridx = 1;
 			constraints.gridy = 0;
+			/*
+			 * LMandtler: I changed the Spinner Constructor call to allow values between 
+			 * -Game.MAX_POPULATION and Game.MAX_POPULATION
+			 * , so user will be available to type in negative numbers
+			 * Then I added a change listener, which, when negative numbers were typed in, will get the current population count.
+			 */
 			this.spinner = new AutoFocusSpinner(
-					new SpinnerNumberModel(CensusDialog.this.client.getGame().getCivilization(name).getPopulation(), 1,
+					new SpinnerNumberModel(CensusDialog.this.client.getGame().getCivilization(name).getPopulation(), -Game.MAX_POPULATION,
 							Game.MAX_POPULATION, 1));
 			this.spinner.setFont(this.spinner.getFont().deriveFont(fontSize));
+
+			
+			this.spinner.addChangeListener(new ChangeListener() {
+				public void stateChanged(ChangeEvent e) {
+					AutoFocusSpinner spinner = (AutoFocusSpinner) e.getSource();
+					int currentValue = (int) spinner.getValue();
+					if(currentValue < 0)
+					{
+						spinner.setValue(Game.MAX_POPULATION + currentValue);
+					}
+				}
+			});
+		
 			this.add(this.spinner, constraints);
 		}
 

--- a/src/net/bubbaland/megaciv/client/gui/CivEditPanel.java
+++ b/src/net/bubbaland/megaciv/client/gui/CivEditPanel.java
@@ -335,7 +335,9 @@ public class CivEditPanel extends BubbaPanel implements ActionListener, ChangeLi
 
 		public void updateGui() {
 			final String text = String.format("%03d", CivEditPanel.this.civ.getVP());
-			this.vpLabel.setText(text);
+			if(CivEditPanel.this.client.getGame().isGameOver() || CivEditPanel.this.client.getGame().showVP()) {
+				this.vpLabel.setText(text);
+			}
 
 			for (final Technology.Type type : EnumSet.allOf(Technology.Type.class)) {
 				this.creditLabels.get(type).setText(CivEditPanel.this.civ.getTypeCredit(type) + "");

--- a/src/net/bubbaland/megaciv/client/gui/CivInfoPanel.java
+++ b/src/net/bubbaland/megaciv/client/gui/CivInfoPanel.java
@@ -258,9 +258,10 @@ public class CivInfoPanel extends BubbaMainPanel {
 			this.cityLabel.setText(civ.getCityCount() + "");
 			this.techLabel.setText(String.format("%02d", civ.getTechs().size()));
 
-			final String text = String.format("%03d", civ.getVP());
-			this.vpLabel.setText(text);
-
+			if(CivInfoPanel.this.client.getGame().isGameOver() || CivInfoPanel.this.client.getGame().showVP()) {
+				final String text = String.format("%03d", civ.getVP());
+				this.vpLabel.setText(text);
+			}
 			// this.techDetailL1Label.setText(civ.getTechCountByVP(1) + "");
 			// this.techDetailL2Label.setText(civ.getTechCountByVP(3) + "");
 			// this.techDetailL3Label.setText(civ.getTechCountByVP(6) + "");

--- a/src/net/bubbaland/megaciv/client/gui/NewGameDialog.java
+++ b/src/net/bubbaland/megaciv/client/gui/NewGameDialog.java
@@ -51,6 +51,7 @@ public class NewGameDialog extends BubbaDialogPanel implements ActionListener, C
 	private final JRadioButton							eastRadioButton, westRadioButton;
 	private final JRadioButton							basicRadioButton, expertRadioButton;
 	private final JCheckBox								useCreditsCheckbox;
+	private final JCheckBox								showVictoryPoints;
 	private final HashMap<Civilization.Name, CivPanel>	civPanels;
 	private final GameClient							client;
 
@@ -88,6 +89,12 @@ public class NewGameDialog extends BubbaDialogPanel implements ActionListener, C
 		this.useCreditsCheckbox = new JCheckBox("Use start game credits");
 		this.useCreditsCheckbox.setSelected(true);
 		this.add(this.useCreditsCheckbox, constraints);
+
+		constraints.gridx = 1;
+		constraints.gridy = 1;
+		this.showVictoryPoints = new JCheckBox("Show Victory Points");
+		this.showVictoryPoints.setSelected(true);
+		this.add(this.showVictoryPoints, constraints);
 
 		fontSize = Float.parseFloat(props.getProperty("NewGameDialog.Option.FontSize"));
 		final ButtonGroup regionGroup = new ButtonGroup();
@@ -288,7 +295,7 @@ public class NewGameDialog extends BubbaDialogPanel implements ActionListener, C
 			final Difficulty difficulty = this.basicRadioButton.isSelected() ? Difficulty.BASIC : Difficulty.EXPERT;
 			this.client.log("Starting new game with the following civilizations: " + startingCivs);
 			this.client.sendMessage(new NewGameMessage(this.getRegion(), startingCivs, difficulty,
-					this.useCreditsCheckbox.isSelected()));
+					this.useCreditsCheckbox.isSelected(), this.showVictoryPoints.isSelected()));
 		}
 	}
 

--- a/src/net/bubbaland/megaciv/game/Civilization.java
+++ b/src/net/bubbaland/megaciv/game/Civilization.java
@@ -126,7 +126,7 @@ public class Civilization implements Serializable, Comparable<Civilization> {
 	public static enum SortDirection {
 		DESCENDING, ASCENDING;
 	}
-
+	
 	/**
 	 * The civilization name
 	 */

--- a/src/net/bubbaland/megaciv/game/Game.java
+++ b/src/net/bubbaland/megaciv/game/Game.java
@@ -108,24 +108,29 @@ public class Game implements Serializable {
 	@JsonProperty("region")
 	private Region							region;
 
+	@JsonProperty("showVP")
+	private boolean					showVP;
+
 	@JsonProperty("gameLog")
 	private final ArrayList<GameEvent>		gameLog;
 
 	public Game() {
-		this(null, new ArrayList<Civilization>(), null, 1, Integer.MAX_VALUE, new ArrayList<GameEvent>());
+		this(null, new ArrayList<Civilization>(), null, 1, Integer.MAX_VALUE, new ArrayList<GameEvent>(), true);
 	}
 
 	@JsonCreator
 	public Game(@JsonProperty("region") final Region region, @JsonProperty("civs") final ArrayList<Civilization> civs,
 			@JsonProperty("difficulty") final Difficulty difficulty,
 			@JsonProperty("currentRound") final int currentRound, @JsonProperty("lastRound") final int lastRound,
-			@JsonProperty("gameLog") final ArrayList<GameEvent> gameLog) {
+			@JsonProperty("gameLog") final ArrayList<GameEvent> gameLog,
+			@JsonProperty("showVP") final boolean showVP) {
 		this.region = region;
 		this.civs = civs;
 		this.currentRound = currentRound;
 		this.lastRound = lastRound;
 		this.difficulty = difficulty;
 		this.gameLog = gameLog;
+		this.showVP = showVP;
 	}
 
 	public ArrayList<GameEvent> getLog() {
@@ -142,6 +147,14 @@ public class Game implements Serializable {
 
 	public Region getRegion() {
 		return this.region;
+	}
+
+	public void setShowVP(final boolean showVP) {
+		this.showVP = showVP;
+	}
+
+	public boolean showVP() {
+		return this.showVP;
 	}
 
 	public TradeCardSet getTradeCards() {

--- a/src/net/bubbaland/megaciv/messages/NewGameMessage.java
+++ b/src/net/bubbaland/megaciv/messages/NewGameMessage.java
@@ -20,16 +20,20 @@ public class NewGameMessage implements ClientMessage {
 	private final Civilization.Region					region;
 	@JsonProperty("useCredits")
 	private final boolean								useCredits;
+	@JsonProperty("showVP")
+	private final boolean								showVP;
 
 	@JsonCreator
 	public NewGameMessage(@JsonProperty("Region") final Civilization.Region region,
 			@JsonProperty("civNames") final HashMap<Civilization.Name, String> newCivNames,
 			@JsonProperty("Difficulty") final Difficulty difficulty,
-			@JsonProperty("useCredits") final boolean useCredits) {
+			@JsonProperty("useCredits") final boolean useCredits,
+			@JsonProperty("showVP") final boolean showVP) {
 		this.region = region;
 		this.civNames = newCivNames;
 		this.difficulty = difficulty;
 		this.useCredits = useCredits;
+		this.showVP = showVP;
 	}
 
 	public Civilization.Region getRegion() {
@@ -46,6 +50,10 @@ public class NewGameMessage implements ClientMessage {
 
 	public boolean useCredits() {
 		return this.useCredits;
+	}
+
+	public boolean showVP() {
+		return this.showVP;
 	}
 
 	@Override

--- a/src/net/bubbaland/megaciv/server/GameServer.java
+++ b/src/net/bubbaland/megaciv/server/GameServer.java
@@ -139,6 +139,8 @@ public class GameServer extends Server {
 				this.game.setDifficulty(difficulty);
 				final Civilization.Region region = ( (NewGameMessage) message ).getRegion();
 				this.game.setRegion(region);
+				final boolean showVP = ( (NewGameMessage) message ).showVP();
+				this.game.setShowVP(showVP);
 
 				// this.log(user + " created new " + WordUtils.capitalizeFully(difficulty.toString())
 				// + " game with the following civilizations: " + startingCivs);


### PR DESCRIPTION
Hi bubba,

when we were using your client 2 weeks ago, it really helped us to get our game along. However, we missed 2 abilities, so here is a pull request, to bring both of those into your app:

1)
Ability to type in negative numbers in the census population, which is in most situations easier to get and you don't have to calculate the correct numbers in your head (which can be difficult after a few hours into the game.

2) Our game group really likes the surprise of "Who won the game" in the end, so we had a strip of paper over our monitor to cover the victory points during the game. Thus, I added an option in the "NewGameDialog" to show or hide VP during the game. If you hide them, you cannot see the VP in any Dialog (AST table, Civ Panel, Civ Edit Panel) if the game is not in GameOver state.

So, if this helps you, I am willing to do more work on the app!
Thanks!
